### PR TITLE
release

### DIFF
--- a/webfront3/package-lock.json
+++ b/webfront3/package-lock.json
@@ -19,7 +19,7 @@
                 "@types/node": "20.3.2",
                 "@types/react": "18.2.14",
                 "eslint": "8.43.0",
-                "eslint-config-next": "13.4.7",
+                "eslint-config-next": "^12.3.4",
                 "eslint-config-prettier": "^8.8.0",
                 "prettier": "2.8.8",
                 "typescript": "5.1.3"
@@ -141,9 +141,9 @@
             "integrity": "sha512-H/69Lc5Q02dq3o+dxxy5O/oNxFsZpdL6WREtOOtOM1B/weonIwDXkekr1KV5DPVPr12IHFPrMrcJQ6bgPMfn7A=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "13.4.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.7.tgz",
-            "integrity": "sha512-ANEPltxzXbyyG7CvqxdY4PmeM5+RyWdAJGufTHnU+LA/i3J6IDV2r8Z4onKwskwKEhwqzz5lMaSYGGXLyHX+mg==",
+            "version": "12.3.4",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.4.tgz",
+            "integrity": "sha512-BFwj8ykJY+zc1/jWANsDprDIu2MgwPOIKxNVnrKvPs+f5TPegrVnem8uScND+1veT4B7F6VeqgaNLFW1Hzl9Og==",
             "dev": true,
             "dependencies": {
                 "glob": "7.1.7"
@@ -377,26 +377,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@pkgr/utils": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
-            "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "fast-glob": "^3.3.0",
-                "is-glob": "^4.0.3",
-                "open": "^9.1.0",
-                "picocolors": "^1.0.0",
-                "tslib": "^2.6.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unts"
             }
         },
         "node_modules/@rushstack/eslint-patch": {
@@ -802,27 +782,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/bplist-parser": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-            "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-            "dev": true,
-            "dependencies": {
-                "big-integer": "^1.6.44"
-            },
-            "engines": {
-                "node": ">= 5.10.0"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -843,21 +802,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/bundle-name": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
-            "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
-            "dev": true,
-            "dependencies": {
-                "run-applescript": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/call-bind": {
@@ -998,52 +942,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-        "node_modules/default-browser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
-            "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
-            "dev": true,
-            "dependencies": {
-                "bundle-name": "^3.0.0",
-                "default-browser-id": "^3.0.0",
-                "execa": "^7.1.1",
-                "titleize": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
-            "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
-            "dev": true,
-            "dependencies": {
-                "bplist-parser": "^0.2.0",
-                "untildify": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/define-properties": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
@@ -1098,19 +996,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true
-        },
-        "node_modules/enhanced-resolve": {
-            "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-            "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
         },
         "node_modules/es-abstract": {
             "version": "1.22.1",
@@ -1274,16 +1159,16 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "13.4.7",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.7.tgz",
-            "integrity": "sha512-+IRAyD0+J1MZaTi9RQMPUfr6Q+GCZ1wOkK6XM52Vokh7VI4R6YFGOFzdkEFHl4ZyIX4FKa5vcwUP2WscSFNjNQ==",
+            "version": "12.3.4",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.4.tgz",
+            "integrity": "sha512-WuT3gvgi7Bwz00AOmKGhOeqnyA5P29Cdyr0iVjLyfDbk+FANQKcOjFUTZIdyYfe5Tq1x4TGcmoe4CwctGvFjHQ==",
             "dev": true,
             "dependencies": {
-                "@next/eslint-plugin-next": "13.4.7",
+                "@next/eslint-plugin-next": "12.3.4",
                 "@rushstack/eslint-patch": "^1.1.3",
-                "@typescript-eslint/parser": "^5.42.0",
+                "@typescript-eslint/parser": "^5.21.0",
                 "eslint-import-resolver-node": "^0.3.6",
-                "eslint-import-resolver-typescript": "^3.5.2",
+                "eslint-import-resolver-typescript": "^2.7.1",
                 "eslint-plugin-import": "^2.26.0",
                 "eslint-plugin-jsx-a11y": "^6.5.1",
                 "eslint-plugin-react": "^7.31.7",
@@ -1332,60 +1217,43 @@
             }
         },
         "node_modules/eslint-import-resolver-typescript": {
-            "version": "3.5.5",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz",
-            "integrity": "sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+            "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.4",
-                "enhanced-resolve": "^5.12.0",
-                "eslint-module-utils": "^2.7.4",
-                "get-tsconfig": "^4.5.0",
-                "globby": "^13.1.3",
-                "is-core-module": "^2.11.0",
+                "glob": "^7.2.0",
                 "is-glob": "^4.0.3",
-                "synckit": "^0.8.5"
+                "resolve": "^1.22.0",
+                "tsconfig-paths": "^3.14.1"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+                "node": ">=4"
             },
             "peerDependencies": {
                 "eslint": "*",
                 "eslint-plugin-import": "*"
             }
         },
-        "node_modules/eslint-import-resolver-typescript/node_modules/globby": {
-            "version": "13.2.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-            "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+        "node_modules/eslint-import-resolver-typescript/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dev": true,
             "dependencies": {
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.3.0",
-                "ignore": "^5.2.4",
-                "merge2": "^1.4.1",
-                "slash": "^4.0.0"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": "*"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/eslint-import-resolver-typescript/node_modules/slash": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/eslint-module-utils": {
@@ -1465,23 +1333,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/eslint-plugin-import/node_modules/resolve": {
-            "version": "1.22.3",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-            "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
-            "dev": true,
-            "dependencies": {
-                "is-core-module": "^2.12.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -1698,29 +1549,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/execa": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-            "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.1",
-                "human-signals": "^4.3.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^3.0.7",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1898,18 +1726,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -1924,18 +1740,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-tsconfig": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.2.tgz",
-            "integrity": "sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==",
-            "dev": true,
-            "dependencies": {
-                "resolve-pkg-maps": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/glob": {
@@ -2032,12 +1836,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
-        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2123,15 +1921,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-            "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.18.0"
             }
         },
         "node_modules/ignore": {
@@ -2279,21 +2068,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2313,24 +2087,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-negative-zero": {
@@ -2406,18 +2162,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-string": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -2473,33 +2217,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-wsl/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isarray": {
@@ -2657,12 +2374,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
-        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2683,18 +2394,6 @@
             },
             "engines": {
                 "node": ">=8.6"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimatch": {
@@ -2797,33 +2496,6 @@
                 "sass": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-            "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/object-assign": {
@@ -2951,39 +2623,6 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/open": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-            "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-            "dev": true,
-            "dependencies": {
-                "default-browser": "^4.0.0",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/optionator": {
@@ -3244,12 +2883,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
+            "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.12.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -3267,15 +2906,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/resolve-pkg-maps": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
         "node_modules/reusify": {
@@ -3301,110 +2931,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/run-applescript": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
-            "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
-            "dev": true,
-            "dependencies": {
-                "execa": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-applescript/node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/run-applescript/node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
-        "node_modules/run-applescript/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-applescript/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/run-applescript/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/run-applescript/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-applescript/node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/run-parallel": {
@@ -3520,12 +3046,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3628,18 +3148,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3695,48 +3203,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/synckit": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-            "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
-            "dev": true,
-            "dependencies": {
-                "@pkgr/utils": "^2.3.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unts"
-            }
-        },
-        "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
-        },
-        "node_modules/titleize": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
-            "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -3903,15 +3374,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/untildify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/uri-js": {

--- a/webfront3/package.json
+++ b/webfront3/package.json
@@ -21,7 +21,7 @@
         "@types/node": "20.3.2",
         "@types/react": "18.2.14",
         "eslint": "8.43.0",
-        "eslint-config-next": "13.4.7",
+        "eslint-config-next": "^12.3.4",
         "eslint-config-prettier": "^8.8.0",
         "prettier": "2.8.8",
         "typescript": "5.1.3"


### PR DESCRIPTION
Bumps [postcss](https://github.com/postcss/postcss) to 8.4.31 and updates ancestor dependency [next](https://github.com/vercel/next.js). These dependencies need to be updated together.


Updates `postcss` from 8.4.14 to 8.4.31
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.14...8.4.31)

Updates `next` from 12.3.4 to 13.5.4
- [Release notes](https://github.com/vercel/next.js/releases)
- [Changelog](https://github.com/vercel/next.js/blob/canary/release.js)
- [Commits](https://github.com/vercel/next.js/compare/v12.3.4...v13.5.4)

---
updated-dependencies:
- dependency-name: postcss
  dependency-type: indirect
- dependency-name: next
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>